### PR TITLE
Disabled linting and type checking in builds

### DIFF
--- a/frontend/next.config.json
+++ b/frontend/next.config.json
@@ -17,5 +17,11 @@
   "output": "standalone",
   "images": {
     "unoptimized": true
+  },
+  "eslint": {
+    "ignoreDuringBuilds": true
+  },
+  "typescript": {
+    "ignoreBuildErrors": true
   }
 }


### PR DESCRIPTION
Disabling linting and type checking can save some build time. After this change, code changes need to be made more carefully. Remove these optimizations if problems arise.