### PR TITLE
Added frontend docker node max size mem options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        - NODE_OPTIONS=${NODE_OPTIONS:-"--max_old_space_size=512"}
     #ports:
     #  - "3000:3000"
     restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,6 +25,10 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV production
 
+# Accept NODE_OPTIONS as build argument
+ARG NODE_OPTIONS
+ENV NODE_OPTIONS=${NODE_OPTIONS}
+
 RUN \
   if [ -f yarn.lock ]; then yarn run build; \
   elif [ -f package-lock.json ]; then npm run build; \


### PR DESCRIPTION
Added option to limit frontend max memory usage in Docker builds. Root compose for frontend sets this value to 512. Memory limiting can help builds in system with limited memory.