### PR TITLE
Skip faulty files instead of erroring

### DIFF
--- a/backend/app/engine/loaders/file.py
+++ b/backend/app/engine/loaders/file.py
@@ -52,7 +52,7 @@ def get_file_documents(config: FileLoaderConfig):
             DATA_DIR,
             recursive=True,
             filename_as_id=True,
-            raise_on_error=True,
+            raise_on_error=False, # if faulty file, skips instead of erroring
             file_extractor=file_extractor,
         )
         return reader.load_data()


### PR DESCRIPTION
If data folder has files that have issues, by default app would throw an error. After this change faulty files are simply skipped.