### PR TITLE
Changed frontend auth to be optional based on settings

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -22,6 +22,7 @@ Create a `.env.local` file in frontend root and add following:
 - `AUTH_URL` set to `yourbaseurl/api/auth`, is used for redirecting from auth provider.
 - `NEXT_PUBLIC_CHAT_API` which is backend chat API's URL when accessing from browser.
 - `CHAT_API` URL for Nextjs backend to access chat API. Set to `http://backend:8000/api/chat` when using root level `docker-compose.yml`.
+- `USE_TUNNISTAMO` if set, users are required to authenticate before being able to use AI-chat.
 
 Add `AUTH_SECRET` to `.env.local` manually or generate by running:
 ```

--- a/frontend/app/components/header.tsx
+++ b/frontend/app/components/header.tsx
@@ -6,6 +6,8 @@ import { SignOut } from "./auth/signout-button"
 
 export default async function Header() {
   const session = await auth()
+  const useTunnistamo = process.env.USE_TUNNISTAMO
+  const authBtn = session ? <SignOut/> : <SignIn/>
 
   return (
     <header className="bg-background border-b">
@@ -20,7 +22,7 @@ export default async function Header() {
               priority
             />
           </div>
-          {session ? <SignOut/> : <SignIn/>}
+          {useTunnistamo && authBtn}
         </div>
       </div>
     </header>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,9 +9,11 @@ export default async function Home() {
       <div className="py-10 space-y-2 lg:space-y-10 w-[90%] lg:w-[60rem]">
         <h1 className="text-4xl font-bold text-white">Laatukäsikirja-chatbot</h1>
         <div className="h-[65vh] flex">
-          {session ? <ChatSection /> : (
-            <p className="text-white text-lg">Tervetuloa käyttämään Laatukäsikirja chatbottia. Aloita käyttö kirjautumalla ensin sisään.</p>
-            )}
+        {process.env.USE_TUNNISTAMO && !session ? (
+          <p className="text-white text-lg">Tervetuloa käyttämään Laatukäsikirja chatbottia. Aloita käyttö kirjautumalla ensin sisään.</p>
+        ) : (
+          <ChatSection />
+        )}
         </div>
       </div>
     </main>


### PR DESCRIPTION
By default frontend auth using Tunnistamo is not required. When `.env.local` setting `USE_TUNNISTAMO` is set, users are required to authenticate before being able to chat with AI.