### PR TITLE
Added custom query engine tool with eval

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -96,8 +96,14 @@ Your answer should be wrapped in three sticks which follows the following format
 <question 3>
 ```"
 
+# Use custom query engine instead of default one. Custom QE has added functionality e.g. evaluation.
+#USE_CUSTOM_QUERY_ENGINE=True
+
+# The string used to identify answer is not based on retrieved context. Add it to SYSTEM_PROMPT as well.
+NOT_IN_CONTEXT_PHRASE=NOT IN CONTEXT
+
 # The system prompt for the AI model.
-SYSTEM_PROMPT=You are a helpful assistant who helps users with their questions.
+SYSTEM_PROMPT=You are a helpful assistant who helps users with their questions. If you receive NOT IN CONTEXT, tell you dont have the info.
 
 # An additional system prompt to add citation when responding to user questions.
 SYSTEM_CITATION_PROMPT='You have provided information from a knowledge base that has been passed to you in nodes of information.

--- a/backend/app/engine/engine.py
+++ b/backend/app/engine/engine.py
@@ -2,6 +2,7 @@ import os
 from typing import List
 
 from app.engine.index import IndexConfig, get_index
+from app.engine.tools.custom_query_engine import CustomQueryEngineTool
 from app.engine.tools import ToolFactory
 from llama_index.core.agent import AgentRunner
 from llama_index.core.callbacks import CallbackManager
@@ -23,7 +24,9 @@ def get_chat_engine(filters=None, params=None, event_handlers=None, **kwargs):
         query_engine = index.as_query_engine(
             filters=filters, **({"similarity_top_k": top_k} if top_k != 0 else {})
         )
-        query_engine_tool = QueryEngineTool.from_defaults(query_engine=query_engine)
+        use_custom_qe = os.getenv("USE_CUSTOM_QUERY_ENGINE")
+        query_engine_tool = CustomQueryEngineTool.from_defaults(query_engine=query_engine) if use_custom_qe \
+            else QueryEngineTool.from_defaults(query_engine=query_engine)
         tools.append(query_engine_tool)
 
     # Add additional tools

--- a/backend/app/engine/tools/custom_query_engine.py
+++ b/backend/app/engine/tools/custom_query_engine.py
@@ -1,0 +1,34 @@
+import os
+import asyncio
+from llama_index.core.tools.query_engine import QueryEngineTool
+from llama_index.core.tools.types import ToolOutput
+from typing import Any
+from llama_index.core.evaluation import FaithfulnessEvaluator
+from llama_index.core.settings import Settings
+
+
+class CustomQueryEngineTool(QueryEngineTool):
+    async def acall(self, *args: Any, **kwargs: Any) -> ToolOutput:
+        query_str = self._get_query_str(*args, **kwargs)
+
+        # Use the standard asyncio event loop
+        loop = asyncio.get_event_loop_policy().new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        try:
+            response = await self._query_engine.aquery(query_str)
+            evaluator = FaithfulnessEvaluator(llm=Settings.llm)
+            eval_result = await evaluator.aevaluate_response(response=response)
+
+            result = str(response)
+            if not eval_result.passing:
+                result = os.getenv("NOT_IN_CONTEXT_PHRASE", "NOT IN CONTEXT")
+
+            return ToolOutput(
+                content=result,
+                tool_name=self.metadata.name,
+                raw_input={"input": query_str if eval_result.passing else result},
+                raw_output=response,
+            )
+        finally:
+            loop.close()


### PR DESCRIPTION
Added optional custom query engine tool which handles faithfulness evaluation on top of normal querying.
New envs:
- `USE_CUSTOM_QUERY_ENGINE`, set to toggle custom qe on.
- `NOT_IN_CONTEXT_PHRASE`, the phrase AI gets when faithfulness check fails.
- (`SYSTEM_PROMPT`, add above not in context phrase in a suitable way for main AI to reason with)