### PR TITLE
Added frontend env for source score threshold

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -30,6 +30,7 @@ Create a `.env.local` file in frontend root and add following:
 - `AUTH_URL` set to `yourbaseurl/api/auth`, is used for redirecting from auth provider.
 - `NEXT_PUBLIC_CHAT_API` which is backend chat API's URL when accessing from browser.
 - `CHAT_API` URL for Nextjs backend to access chat API. Set to `http://backend:8000/api/chat` when using root level `docker-compose.yml`.
+- `NEXT_PUBLIC_NODE_SCORE_THRESHOLD` AI answer's source score threshold 0.1 - 1 (optional).
 
 Add `AUTH_SECRET` to `.env.local` manually or generate by running:
 

--- a/frontend/app/components/ui/chat/index.ts
+++ b/frontend/app/components/ui/chat/index.ts
@@ -91,7 +91,8 @@ export type MessageAnnotation = {
   data: AnnotationData;
 };
 
-const NODE_SCORE_THRESHOLD = 0.25;
+const ENV_THRESHOLD = process.env.NEXT_PUBLIC_NODE_SCORE_THRESHOLD
+const NODE_SCORE_THRESHOLD = ENV_THRESHOLD ? parseFloat(ENV_THRESHOLD) : 0.25;
 
 export function getAnnotationData<T extends AnnotationData>(
   annotations: MessageAnnotation[],


### PR DESCRIPTION
Optional frontend `NEXT_PUBLIC_NODE_SCORE_THRESHOLD` controls the threshold value which determines when sources are shown in the chat. Lower values mean sources are more likely to be shown and higher values mean sources are more likely not being shown. The new env is optional and default value is `0.25`