### PR TITLE
Added chat input label for screen readers

### DIFF
--- a/frontend/app/components/ui/chat/chat-input.tsx
+++ b/frontend/app/components/ui/chat/chat-input.tsx
@@ -106,6 +106,9 @@ export default function ChatInput(
         </div>
       )}
       <div className="flex w-full items-start justify-between gap-4 ">
+        <label htmlFor="chat-input" className="sr-only">
+          Kirjoita kysymys
+        </label>
         <Textarea
           id="chat-input"
           // autoFocus


### PR DESCRIPTION
Frontend chat input was lacking accessible label for screen readers. This change adds a simple screen reader only label for the chat textarea input.