### PR TITLE
Changed frontend auth issuer to be configurable with env

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,6 +26,7 @@ Create a `.env.local` file in frontend root and add following:
 - `USE_TUNNISTAMO` if set, users are required to authenticate before being able to use AI-chat.
 - `AUTH_CLIENT_ID` given by auth provider (optional, only used when auth provider in use like Tunnistamo).
 - `AUTH_CLIENT_SECRET` given by auth provider (optional, only used when auth provider in use like Tunnistamo).
+- `AUTH_CLIENT_ISSUER` auth provider URL for authentication (optional, testitunnistamo is used as default).
 - `AUTH_TRUST_HOST` set to `"true"`, see more info: <https://authjs.dev/reference/core/errors#untrustedhost>.
 - `AUTH_URL` set to `yourbaseurl/api/auth`, is used for redirecting from auth provider.
 - `NEXT_PUBLIC_CHAT_API` which is backend chat API's URL when accessing from browser.

--- a/frontend/auth.ts
+++ b/frontend/auth.ts
@@ -5,7 +5,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     id: "tunnistamo", // signIn("my-provider") and will be part of the callback URL
     name: "Tunnistamo", // optional, used on the default login page as the button text.
     type: "oidc", // or "oauth" for OAuth 2 providers
-    issuer: "https://testitunnistamo.turku.fi/openid",
+    issuer: process.env.AUTH_CLIENT_ISSUER || "https://testitunnistamo.turku.fi/openid",
     clientId: process.env.AUTH_CLIENT_ID, // from the provider's dashboard
     clientSecret: process.env.AUTH_CLIENT_SECRET, // from the provider's dashboard
   }],


### PR DESCRIPTION
Frontend auth issuer can now be changed with .env.local `AUTH_CLIENT_ISSUER` value. Default auth issuer is still testitunnistamo.